### PR TITLE
Enable calls from netlify frontend

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,12 @@ const register = require("./src/routes/register")
 
 const app = express()
 
-app.use(cors())
+const corsOptions = {
+    origin: 'https://wild-thunder.netlify.app/',
+    optionsSuccessStatus: 200 // some legacy browsers (IE11, various SmartTVs) choke on 204
+}
+
+app.use(cors(corsOptions))
 app.use(morgan("dev"))
 app.use(express.json())
 app.use(express.urlencoded({extended: true}))


### PR DESCRIPTION
In the file index.js, we have created a const corsOptions to enable calls from https://wild-thunder.netlify.app/.